### PR TITLE
Mark javalogger repo as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Liquibase java.util.Logger Extension
 ========================
 
+# DEPRECATED
+
+Liquibase now uses java.util.Logger by default, so this extension is no longer needed
+
 
 This extension changes the Liquibase logging system to use the java.util.Logger rather than STDOUT.
 


### PR DESCRIPTION
The java.util.logger has been moved into liquibase-core since 4.0. We can deprecate this repo as it is no longer needed.